### PR TITLE
Fix for kernel 6.15 (R3n4n patch)

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = nvidia-340xx
 	pkgdesc = NVIDIA drivers for linux, 340xx legacy branch
 	pkgver = 340.108
-	pkgrel = 38
+	pkgrel = 39
 	url = https://www.nvidia.com/
 	arch = x86_64
 	license = custom
@@ -30,6 +30,7 @@ pkgbase = nvidia-340xx
 	source = 0016-kernel-6.8.patch
 	source = 0017-gcc-14.patch
 	source = 0018-gcc-15.patch
+	source = 0019-kernel-6.15.patch
 	b2sums = 6538bbec53b10f8d20977f9b462052625742e9709ef06e24cf2e55de5d0c55f1620a4bb21396cfd89ebc54c32f921ea17e3e47eaa95abcbc24ecbd144fb89028
 	b2sums = 49d99f612e8eee3ab5e34083c25348bfd14ed5fc8a7984dafc0dad7c0ae0df2c0b2a63a1bb993da440eb0a60293d7c753ca3889bd2f51991b8ddc51bce2fe4a8
 	b2sums = 7150233df867a55f57aa5e798b9c7618329d98459fecc35c4acfad2e9772236cb229703c4fa072381c509279d0588173d65f46297231f4d3bfc65a1ef52e65b1
@@ -50,6 +51,7 @@ pkgbase = nvidia-340xx
 	b2sums = 834cebe75ee128d3a3dc69c1e65c579c23a6d39b1dedd77d1333057696168d264a8131dab88997d73801595fa46bf69a8be02411a383bb2067744cbf754c61a0
 	b2sums = fd8393baf8bb3e41a523df0edb82098172d350631e0002eb8dea4a07e40c56687eefa57360e268d908a11a8b7519d7d98b30290cb3e0c00645d85bde899f151b
 	b2sums = bf9cea1ec7f1a74d302e7f99544bff88eb846a014a4fb9de96928291ddcaf09c9f40f4ec6f1995e132991b9d7fe0a9ce696ba9e820559cde981fce3bcde06823
+	b2sums = f06a0171e31b0254e0480df25b5f86ca575434822fd7d4a791da9856159c17a82195896ab2a43ab68442d6026d991d8ae2701afb9f8b6e35bf4d336809f60193
 
 pkgname = nvidia-340xx
 	pkgdesc = NVIDIA drivers for linux, 340xx legacy branch

--- a/0019-kernel-6.15.patch
+++ b/0019-kernel-6.15.patch
@@ -1,0 +1,245 @@
+--- a/kernel/conftest.sh	2025-07-27 23:48:51.829248168 +0000
++++ b/kernel/conftest.sh	2025-07-27 23:52:39.483549229 +0000
+@@ -196,7 +196,7 @@
+ }
+ 
+ build_cflags() {
+-    BASE_CFLAGS="-std=gnu17 -O2 -Wno-implicit-function-declaration -Wno-incompatible-pointer-types -D__KERNEL__ \
++    BASE_CFLAGS="-I${SCRIPTDIR} -std=gnu17 -O2 -Wno-implicit-function-declaration -Wno-incompatible-pointer-types -D__KERNEL__ \
+ -DKBUILD_BASENAME=\"#conftest$$\" -DKBUILD_MODNAME=\"#conftest$$\" \
+ -nostdinc -isystem $ISYSTEM"
+ 
+--- a/kernel/Makefile	2025-07-27 23:48:51.675247965 +0000
++++ b/kernel/Makefile	2025-07-27 23:52:39.487837357 +0000
+@@ -164,16 +164,16 @@
+ #
+ 
+ ifdef NV_BUILD_MODULE_INSTANCES
+- EXTRA_CFLAGS += -DNV_BUILD_MODULE_INSTANCES=1
++ ccflags-y += -DNV_BUILD_MODULE_INSTANCES=1
+  ifneq ($(NV_MODULE_SUFFIX),frontend)
+- EXTRA_CFLAGS += -DNV_MODULE_INSTANCE=$(NV_MODULE_SUFFIX)
++ ccflags-y += -DNV_MODULE_INSTANCE=$(NV_MODULE_SUFFIX)
+  endif
+ else
+- EXTRA_CFLAGS += -DNV_MODULE_INSTANCE=0
+- EXTRA_CFLAGS += -DNV_BUILD_MODULE_INSTANCES=0
++ ccflags-y += -DNV_MODULE_INSTANCE=0
++ ccflags-y += -DNV_BUILD_MODULE_INSTANCES=0
+ endif
+ 
+-EXTRA_CFLAGS += -UDEBUG -U_DEBUG -DNDEBUG
++ccflags-y += -UDEBUG -U_DEBUG -DNDEBUG
+ 
+ #
+ # Include common definitions; we rely on the definition of the source path to
+--- a/kernel/nv.c	2025-07-27 23:48:51.713423001 +0000
++++ b/kernel/nv.c	2025-07-27 23:52:39.488549236 +0000
+@@ -2447,7 +2447,13 @@
+ 
+     nv_printf(NV_DBG_INFO, "NVRM: stopping rc timer\n");
+     nv->rc_timer_enabled = 0;
++// Rel. commit "treewide: Switch/rename to timer_delete[_sync]()" (Thomas Gleixner, 5 Apr 2025)
++// This provides a shim for ancient kernels before timer_delete_sync was introduced
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++    timer_delete_sync(&nvl->rc_timer);
++#else
+     del_timer_sync(&nvl->rc_timer);
++#endif
+     nv_printf(NV_DBG_INFO, "NVRM: rc timer stopped\n");
+ 
+     return 0;
+--- a/kernel/nvidia-modules-common.mk	2025-07-27 23:48:51.832248172 +0000
++++ b/kernel/nvidia-modules-common.mk	2025-07-27 23:54:45.204715783 +0000
+@@ -37,8 +37,9 @@
+ # warning types that are of little interest to us.
+ #
+ 
+-EXTRA_CFLAGS += -I$(src)
+-EXTRA_CFLAGS += -Wall -MD $(DEFINES) $(INCLUDES) -Wsign-compare -Wno-cast-qual -Wno-error
++ccflags-y += -std=gnu17
++ccflags-y += -I$(src)
++ccflags-y += -Wall -MD $(DEFINES) $(INCLUDES) -Wno-cast-qual -Wno-error -Wno-format-extra-args
+ 
+ #
+ # Output directory for the build; default to the source directory if not set.
+@@ -116,13 +117,13 @@
+ # NVIDIA specific CFLAGS and #define's.
+ #
+ 
+-EXTRA_CFLAGS += -std=gnu17 -D__KERNEL__ -DMODULE -DNVRM -DNV_VERSION_STRING=\"340.108\" -Wno-unused-function -Wuninitialized -fno-strict-aliasing -mno-red-zone -mcmodel=kernel -DNV_UVM_ENABLE -D__linux__ -DNV_DEV_NAME=\"$(MODULE_NAME)\"
++ccflags-y += -D__KERNEL__ -DMODULE -DNVRM -DNV_VERSION_STRING=\"340.108\" -Wno-unused-function -Wuninitialized -fno-strict-aliasing -mno-red-zone -mcmodel=kernel -DNV_UVM_ENABLE -D__linux__ -DNV_DEV_NAME=\"$(MODULE_NAME)\"
+ 
+ #
+ # Detect SGI UV systems and apply system-specific optimizations.
+ #
+ ifneq ($(wildcard /proc/sgi_uv),)
+- EXTRA_CFLAGS += -DNV_CONFIG_X86_UV
++ ccflags-y += -DNV_CONFIG_X86_UV
+ endif
+ 
+ #
+@@ -306,6 +307,8 @@
+ # kernel interface is built.
+ #
+ 
++nvidia.o: override objtool-enabled =
++
+ $(KERNEL_GLUE_NAME): $(MODULE_OBJECT)
+ 	@$(LD) $(EXTRA_LDFLAGS) $(MODULE_COMMON_SCRIPT) -r -o $(KERNEL_GLUE_NAME) $(KERNEL_GLUE_OBJS)
+ 
+--- a/kernel/nv-linux.h	2025-07-27 23:48:51.807560718 +0000
++++ b/kernel/nv-linux.h	2025-07-27 23:52:39.493549243 +0000
+@@ -2303,4 +2303,39 @@
+ #endif
+ #endif
+ 
++static inline void nv_vm_flags_set(struct vm_area_struct *vma, vm_flags_t flags)
++{
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++    // Rel. commit "mm: uninline the main body of vma_start_write()" (Suren Baghdasaryan, 13 Feb 2025)
++    // Since Linux 6.15, vm_flags_set and vm_flags_clear call a GPL-only symbol
++    // for locking (__vma_start_write), which can't be called from non-GPL code.
++    // However, it appears all uses on the driver are on VMAs being initially
++    // mapped / which are already locked, so we can use vm_flags_reset, which
++    // doesn't lock the VMA, but rather just asserts it is already write-locked.
++    vm_flags_reset(vma, vma->vm_flags | flags);
++#else
++    vm_flags_set(vma, flags);
++#endif
++}
++
++static inline void nv_vm_flags_clear(struct vm_area_struct *vma, vm_flags_t flags)
++{
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++    // Rel. commit "mm: uninline the main body of vma_start_write()" (Suren Baghdasaryan, 13 Feb 2025)
++    // See above
++    vm_flags_reset(vma, vma->vm_flags & ~flags);
++#else
++    vm_flags_clear(vma, flags);
++#endif
++}
++
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
++// Rel. commit "treewide: Switch/rename to timer_delete[_sync]()" (Thomas Gleixner, 5 Apr 2025)
++// This provides a shim for ancient kernels before timer_delete_sync was introduced
++static inline int timer_delete_sync(struct timer_list *timer)
++{
++    return del_timer_sync(timer);
++}
++#endif
++
+ #endif  /* _NV_LINUX_H_ */
+--- a/kernel/nv-mmap.c	2025-07-27 23:48:51.796004133 +0000
++++ b/kernel/nv-mmap.c	2025-07-27 23:52:39.498549249 +0000
+@@ -313,7 +313,7 @@
+         }
+ 
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+-        vm_flags_set(vma, VM_IO);
++        nv_vm_flags_set(vma, VM_IO);
+ #else
+         vma->vm_flags |= VM_IO;
+ #endif
+@@ -368,8 +368,8 @@
+         NV_PRINT_AT(NV_DBG_MEMINFO, at);
+ 
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+-        vm_flags_set(vma, VM_IO | VM_LOCKED | VM_RESERVED);
+-        vm_flags_set(vma, VM_DONTEXPAND | VM_DONTDUMP);
++        nv_vm_flags_set(vma, VM_IO | VM_LOCKED | VM_RESERVED);
++        nv_vm_flags_set(vma, VM_DONTEXPAND | VM_DONTDUMP);
+ #else
+         vma->vm_flags |= (VM_IO | VM_LOCKED | VM_RESERVED);
+         vma->vm_flags |= (VM_DONTEXPAND | VM_DONTDUMP);
+--- a/kernel/uvm/nvidia_uvm_common.c	2019-12-11 22:04:24.000000000 +0000
++++ b/kernel/uvm/nvidia_uvm_common.c	2025-07-28 00:07:11.804439538 +0000
+@@ -355,5 +355,6 @@
+ 
+ module_init(uvm_init);
+ module_exit(uvm_exit);
++MODULE_DESCRIPTION("NVIDIA GPU UVM kernel module");
+ MODULE_LICENSE("MIT");
+ MODULE_INFO(supported, "external");
+--- a/kernel/uvm/nvidia_uvm_linux.h	2025-07-27 23:48:51.737065000 +0000
++++ b/kernel/uvm/nvidia_uvm_linux.h	2025-07-27 23:52:39.499549251 +0000
+@@ -451,5 +451,31 @@
+ }
+ #endif
+ 
++static inline void nv_vm_flags_set(struct vm_area_struct *vma, vm_flags_t flags)
++{
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++    // Rel. commit "mm: uninline the main body of vma_start_write()" (Suren Baghdasaryan, 13 Feb 2025)
++    // Since Linux 6.15, vm_flags_set and vm_flags_clear call a GPL-only symbol
++    // for locking (__vma_start_write), which can't be called from non-GPL code.
++    // However, it appears all uses on the driver are on VMAs being initially
++    // mapped / which are already locked, so we can use vm_flags_reset, which
++    // doesn't lock the VMA, but rather just asserts it is already write-locked.
++    vm_flags_reset(vma, vma->vm_flags | flags);
++#else
++    vm_flags_set(vma, flags);
++#endif
++}
++
++static inline void nv_vm_flags_clear(struct vm_area_struct *vma, vm_flags_t flags)
++{
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++    // Rel. commit "mm: uninline the main body of vma_start_write()" (Suren Baghdasaryan, 13 Feb 2025)
++    // See above
++    vm_flags_reset(vma, vma->vm_flags & ~flags);
++#else
++    vm_flags_clear(vma, flags);
++#endif
++}
++
+ #endif // _NVIDIA_UVM_LINUX_H
+ 
+--- a/kernel/uvm/nvidia_uvm_lite.c	2025-07-27 23:48:51.797446558 +0000
++++ b/kernel/uvm/nvidia_uvm_lite.c	2025-07-28 00:14:58.937339255 +0000
+@@ -1526,9 +1526,9 @@
+ 
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+         // Prohibit copying the vma on fork().
+-        vm_flags_set(vma, VM_DONTCOPY);
++        nv_vm_flags_set(vma, VM_DONTCOPY);
+         // Prohibt mremap() that would expand the vma.
+-        vm_flags_set(vma, VM_DONTEXPAND);
++        nv_vm_flags_set(vma, VM_DONTEXPAND);
+ #else
+         // Prohibit copying the vma on fork().
+         vma->vm_flags |= VM_DONTCOPY;
+@@ -1554,9 +1554,9 @@
+ 
+         vma->vm_ops = &counters_vma_ops;
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+-        vm_flags_clear(vma, VM_MAYWRITE);
++        nv_vm_flags_clear(vma, VM_MAYWRITE);
+         // prevent vm_insert_page from modifying the vma's flags:
+-        vm_flags_set(vma, VM_MIXEDMAP);
++        nv_vm_flags_set(vma, VM_MIXEDMAP);
+ #else
+         vma->vm_flags &= ~VM_MAYWRITE;
+         // prevent vm_insert_page from modifying the vma's flags:
+@@ -2541,8 +2541,8 @@
+     // a SIGSEGV.
+     //
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+-    vm_flags_clear(vma, VM_READ|VM_MAYREAD);
+-    vm_flags_clear(vma, VM_WRITE|VM_MAYWRITE);
++    nv_vm_flags_clear(vma, VM_READ|VM_MAYREAD);
++    nv_vm_flags_clear(vma, VM_WRITE|VM_MAYWRITE);
+ #else
+     vma->vm_flags &= ~(VM_READ|VM_MAYREAD);
+     vma->vm_flags &= ~(VM_WRITE|VM_MAYWRITE);
+@@ -2555,8 +2555,8 @@
+ static void _set_vma_accessible(struct vm_area_struct * vma)
+ {
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+-    vm_flags_set(vma, VM_READ|VM_MAYREAD);
+-    vm_flags_set(vma, VM_WRITE|VM_MAYWRITE);
++    nv_vm_flags_set(vma, VM_READ|VM_MAYREAD);
++    nv_vm_flags_set(vma, VM_WRITE|VM_MAYWRITE);
+ #else
+     vma->vm_flags |= (VM_READ|VM_MAYREAD);
+     vma->vm_flags |= (VM_WRITE|VM_MAYWRITE);

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@
 pkgbase=nvidia-340xx
 pkgname=(nvidia-340xx nvidia-340xx-dkms); [ -n "$NVIDIA_340XX_DKMS_ONLY" ] && pkgname=(nvidia-340xx-dkms)
 pkgver=340.108
-pkgrel=38
+pkgrel=39
 pkgdesc="NVIDIA drivers for linux, 340xx legacy branch"
 arch=('x86_64')
 url="https://www.nvidia.com/"
@@ -15,7 +15,8 @@ conflicts=('nvidia')
 license=('custom')
 options=(!strip)
 # https://github.com/warpme/minimyth2/tree/master/script/nvidia/nvidia-340.108/files
-source=("https://us.download.nvidia.com/XFree86/Linux-x86_64/${pkgver}/NVIDIA-Linux-x86_64-${pkgver}-no-compat32.run"
+source=(
+  "https://us.download.nvidia.com/XFree86/Linux-x86_64/${pkgver}/NVIDIA-Linux-x86_64-${pkgver}-no-compat32.run"
   20-nvidia.conf
   0001-kernel-5.7.patch
   0002-kernel-5.8.patch
@@ -35,6 +36,7 @@ source=("https://us.download.nvidia.com/XFree86/Linux-x86_64/${pkgver}/NVIDIA-Li
   0016-kernel-6.8.patch
   0017-gcc-14.patch
   0018-gcc-15.patch
+  0019-kernel-6.15.patch
 )
 b2sums=('6538bbec53b10f8d20977f9b462052625742e9709ef06e24cf2e55de5d0c55f1620a4bb21396cfd89ebc54c32f921ea17e3e47eaa95abcbc24ecbd144fb89028'
         '49d99f612e8eee3ab5e34083c25348bfd14ed5fc8a7984dafc0dad7c0ae0df2c0b2a63a1bb993da440eb0a60293d7c753ca3889bd2f51991b8ddc51bce2fe4a8'
@@ -55,7 +57,8 @@ b2sums=('6538bbec53b10f8d20977f9b462052625742e9709ef06e24cf2e55de5d0c55f1620a4bb
         '5e88a31f1f25744b1136ac8972f652dbfb63cbd9d54596f616e7c861ac3ce624554ea68b6a7f99c275495d2f55f755b7208ada161cd25c449166dd5cce3050a2'
         '834cebe75ee128d3a3dc69c1e65c579c23a6d39b1dedd77d1333057696168d264a8131dab88997d73801595fa46bf69a8be02411a383bb2067744cbf754c61a0'
         'fd8393baf8bb3e41a523df0edb82098172d350631e0002eb8dea4a07e40c56687eefa57360e268d908a11a8b7519d7d98b30290cb3e0c00645d85bde899f151b'
-        'bf9cea1ec7f1a74d302e7f99544bff88eb846a014a4fb9de96928291ddcaf09c9f40f4ec6f1995e132991b9d7fe0a9ce696ba9e820559cde981fce3bcde06823')
+        'bf9cea1ec7f1a74d302e7f99544bff88eb846a014a4fb9de96928291ddcaf09c9f40f4ec6f1995e132991b9d7fe0a9ce696ba9e820559cde981fce3bcde06823'
+        'f06a0171e31b0254e0480df25b5f86ca575434822fd7d4a791da9856159c17a82195896ab2a43ab68442d6026d991d8ae2701afb9f8b6e35bf4d336809f60193')
 _pkg="NVIDIA-Linux-x86_64-${pkgver}-no-compat32"
 
 # default is 'linux' substitute custom name here


### PR DESCRIPTION
- Add [R3n4n patch](https://codeberg.org/Anakiev/nvidia-340xx-drm/issues/1) to fix for Linux kernel 6.15 (0019-kernel-6.15.patch)
- Update PKGBUILD and .SRCINFO accordingly
- Bump version to 39 (nvidia-340xx-340.108-39)