### PR TITLE
Fixes for kernel 6.19 and 7.1

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = nvidia-340xx
 	pkgdesc = NVIDIA drivers for linux, 340xx legacy branch
 	pkgver = 340.108
-	pkgrel = 39
+	pkgrel = 40
 	url = https://www.nvidia.com/
 	arch = x86_64
 	license = custom
@@ -31,6 +31,7 @@ pkgbase = nvidia-340xx
 	source = 0017-gcc-14.patch
 	source = 0018-gcc-15.patch
 	source = 0019-kernel-6.15.patch
+	source = 0020-kernel-6.19.patch
 	b2sums = 6538bbec53b10f8d20977f9b462052625742e9709ef06e24cf2e55de5d0c55f1620a4bb21396cfd89ebc54c32f921ea17e3e47eaa95abcbc24ecbd144fb89028
 	b2sums = 49d99f612e8eee3ab5e34083c25348bfd14ed5fc8a7984dafc0dad7c0ae0df2c0b2a63a1bb993da440eb0a60293d7c753ca3889bd2f51991b8ddc51bce2fe4a8
 	b2sums = 7150233df867a55f57aa5e798b9c7618329d98459fecc35c4acfad2e9772236cb229703c4fa072381c509279d0588173d65f46297231f4d3bfc65a1ef52e65b1
@@ -52,6 +53,7 @@ pkgbase = nvidia-340xx
 	b2sums = fd8393baf8bb3e41a523df0edb82098172d350631e0002eb8dea4a07e40c56687eefa57360e268d908a11a8b7519d7d98b30290cb3e0c00645d85bde899f151b
 	b2sums = bf9cea1ec7f1a74d302e7f99544bff88eb846a014a4fb9de96928291ddcaf09c9f40f4ec6f1995e132991b9d7fe0a9ce696ba9e820559cde981fce3bcde06823
 	b2sums = f06a0171e31b0254e0480df25b5f86ca575434822fd7d4a791da9856159c17a82195896ab2a43ab68442d6026d991d8ae2701afb9f8b6e35bf4d336809f60193
+	b2sums = d414291e6e4bfce2310a3b8a97dde726500dc1d28de8d435c82412bdbd884969cc76035d78874dd696bc76be9bfb9c125848c4a79459e1dcc06971cf507c1a8c
 
 pkgname = nvidia-340xx
 	pkgdesc = NVIDIA drivers for linux, 340xx legacy branch

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = nvidia-340xx
 	pkgdesc = NVIDIA drivers for linux, 340xx legacy branch
 	pkgver = 340.108
-	pkgrel = 40
+	pkgrel = 41
 	url = https://www.nvidia.com/
 	arch = x86_64
 	license = custom
@@ -32,6 +32,7 @@ pkgbase = nvidia-340xx
 	source = 0018-gcc-15.patch
 	source = 0019-kernel-6.15.patch
 	source = 0020-kernel-6.19.patch
+	source = 0021-kernel-7.0.patch
 	b2sums = 6538bbec53b10f8d20977f9b462052625742e9709ef06e24cf2e55de5d0c55f1620a4bb21396cfd89ebc54c32f921ea17e3e47eaa95abcbc24ecbd144fb89028
 	b2sums = 49d99f612e8eee3ab5e34083c25348bfd14ed5fc8a7984dafc0dad7c0ae0df2c0b2a63a1bb993da440eb0a60293d7c753ca3889bd2f51991b8ddc51bce2fe4a8
 	b2sums = 7150233df867a55f57aa5e798b9c7618329d98459fecc35c4acfad2e9772236cb229703c4fa072381c509279d0588173d65f46297231f4d3bfc65a1ef52e65b1
@@ -54,6 +55,7 @@ pkgbase = nvidia-340xx
 	b2sums = bf9cea1ec7f1a74d302e7f99544bff88eb846a014a4fb9de96928291ddcaf09c9f40f4ec6f1995e132991b9d7fe0a9ce696ba9e820559cde981fce3bcde06823
 	b2sums = f06a0171e31b0254e0480df25b5f86ca575434822fd7d4a791da9856159c17a82195896ab2a43ab68442d6026d991d8ae2701afb9f8b6e35bf4d336809f60193
 	b2sums = d414291e6e4bfce2310a3b8a97dde726500dc1d28de8d435c82412bdbd884969cc76035d78874dd696bc76be9bfb9c125848c4a79459e1dcc06971cf507c1a8c
+        b2sums = 348f934d252bd91ca6753b821b489f16a3b8ff074583eaf38fda6e6bc64aade07b438aa45f7ed34019335c22449d4829a90b5b3192b9e3688e59345bb883f380
 
 pkgname = nvidia-340xx
 	pkgdesc = NVIDIA drivers for linux, 340xx legacy branch

--- a/0020-kernel-6.19.patch
+++ b/0020-kernel-6.19.patch
@@ -1,0 +1,53 @@
+diff -Naur a/kernel/nv-time.h b/kernel/nv-time.h
+--- a/kernel/nv-time.h	2026-04-12 18:45:04.567728445 +0200
++++ b/kernel/nv-time.h	2026-04-12 18:49:15.790678900 +0200
+@@ -33,6 +33,19 @@
+     __kernel_suseconds_t tv_usec;
+ };
+
++/*
++ * in_hardirq() was added in v5.11-rc1 (2020-12-15) to replace in_irq().
++ * Fall back to in_irq() for older kernels that don't have in_hardirq().
++ */
++static inline NvBool nv_in_hardirq(void)
++{
++#if defined(in_hardirq)
++    return in_hardirq();
++#else
++    return in_irq();
++#endif
++}
++
+ static inline void nv_gettimeofday(struct nv_timeval *tv)
+ {
+ #ifdef NV_DO_GETTIMEOFDAY_PRESENT
+diff -Naur a/kernel/os-interface.c b/kernel/os-interface.c
+--- a/kernel/os-interface.c	2026-04-12 19:06:08.431693921 +0200
++++ b/kernel/os-interface.c	2026-04-12 19:09:38.068422032 +0200
+@@ -219,7 +219,7 @@
+ 
+ BOOL NV_API_CALL os_is_isr(void)
+ {
+-    return (in_irq());
++    return (nv_in_hardirq());
+ }
+ 
+ // return TRUE if the caller is the super-user
+@@ -479,7 +479,7 @@
+     nv_gettimeofday(&tm1);
+ #endif
+ 
+-    if (in_irq() && (MicroSeconds > NV_MAX_ISR_DELAY_US))
++    if (nv_in_hardirq() && (MicroSeconds > NV_MAX_ISR_DELAY_US))
+         return RM_ERROR;
+     
+     mdelay_safe_msec = MicroSeconds / 1000;
+@@ -524,7 +524,7 @@
+     tm_start = tm_aux;
+ #endif
+ 
+-    if (in_irq() && (MilliSeconds > NV_MAX_ISR_DELAY_MS))
++    if (nv_in_hardirq() && (MilliSeconds > NV_MAX_ISR_DELAY_MS))
+         return RM_ERROR;
+ 
+     if (!NV_MAY_SLEEP()) 

--- a/0021-kernel-7.0.patch
+++ b/0021-kernel-7.0.patch
@@ -1,0 +1,92 @@
+diff --color --unified --recursive --text a/kernel/conftest.sh b/kernel/conftest.sh
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -196,7 +196,7 @@
+ }
+
+ build_cflags() {
+-    BASE_CFLAGS="-I${SCRIPTDIR} -std=gnu17 -O2 -Wno-implicit-function-declaration -Wno-incompatible-pointer-types -D__KERNEL__ \
++    BASE_CFLAGS="-I${SCRIPTDIR} -std=gnu17 -fms-extensions -Wunused-but-set-variable=3 -O2 -Wno-implicit-function-declaration -Wno-incompatible-pointer-types -D__KERNEL__ \
+ -DKBUILD_BASENAME=\"#conftest$$\" -DKBUILD_MODNAME=\"#conftest$$\" \
+ -nostdinc -isystem $ISYSTEM"
+
+diff --color --unified --recursive --text a/kernel/nv.c b/kernel/nv.c
+--- a/kernel/nv.c
++++ b/kernel/nv.c
+@@ -1455,7 +1455,13 @@
+ #endif
+ #if !defined(NV_VMWARE) && \
+   (defined(NVCPU_X86) || defined(NVCPU_X86_64))
+-        if (nv->primary_vga && (screen_info.orig_video_isVGA != 0x01))
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 20, 0)
++        // Rel. commit "sysfb: Replace screen_info with sysfb_primary_display" (Thomas Zimmermann, 26 Nov 2025)
++        const struct screen_info *si = &sysfb_primary_display.screen;
++#else
++        const struct screen_info *si = &screen_info;
++#endif
++        if (nv->primary_vga && (si->orig_video_isVGA != 0x01))
+         {
+             if (!nv_fbdev_failure_detected)
+             {
+diff --color --unified --recursive --text a/kernel/nvidia-modules-common.mk b/kernel/nvidia-modules-common.mk
+--- a/kernel/nvidia-modules-common.mk
++++ b/kernel/nvidia-modules-common.mk
+@@ -39,7 +39,7 @@
+
+ ccflags-y += -std=gnu17
+ ccflags-y += -I$(src)
+-ccflags-y += -Wall -MD $(DEFINES) $(INCLUDES) -Wno-cast-qual -Wno-error -Wno-format-extra-args
++ccflags-y += -Wunused-but-set-variable=3 -fms-extensions -MD $(DEFINES) $(INCLUDES) -Wno-cast-qual -Wno-error -Wno-format-extra-args
+
+ #
+ # Output directory for the build; default to the source directory if not set.
+diff --color --unified --recursive --text a/kernel/nv-linux.h b/kernel/nv-linux.h
+--- a/kernel/nv-linux.h
++++ b/kernel/nv-linux.h
+@@ -178,6 +178,9 @@
+ #endif
+ #if defined(NV_LINUX_SCREEN_INFO_H_PRESENT)
+ #include <linux/screen_info.h>      /* screen_info                      */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 20, 0)
++#include <linux/sysfb.h>            /* sysfb_primary_display            */
++#endif
+ #else
+ #include <linux/tty.h>              /* screen_info                      */
+ #endif
+diff --color --unified --recursive --text a/kernel/os-interface.c b/kernel/os-interface.c
+--- a/kernel/os-interface.c
++++ b/kernel/os-interface.c
+@@ -1153,12 +1153,18 @@
+ #if !defined(NV_VMWARE) && (defined(NVCPU_X86) || defined(NVCPU_X86_64))
+     if (NV_EFI_ENABLED())
+     {
+-        *pPhysicalAddress = screen_info.lfb_base;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 20, 0)
++        // Rel. commit "sysfb: Replace screen_info with sysfb_primary_display" (Thomas Zimmermann, 26 Nov 2025)
++        const struct screen_info *si = &sysfb_primary_display.screen;
++#else
++        const struct screen_info *si = &screen_info;
++#endif
++        *pPhysicalAddress = si->lfb_base;
+ #if defined(VIDEO_CAPABILITY_64BIT_BASE)
+-        *pPhysicalAddress |= (NvU64)screen_info.ext_lfb_base << 32;
++        *pPhysicalAddress |= (NvU64)si->ext_lfb_base << 32;
+ #endif
+-        *pHeight = screen_info.lfb_height;
+-        *pPitch = screen_info.lfb_linelength;
++        *pHeight = si->lfb_height;
++        *pPitch = si->lfb_linelength;
+         return RM_OK;
+     }
+ #endif
+diff --color --unified --recursive --text a/kernel/uvm/conftest.sh b/kernel/uvm/conftest.sh
+--- a/kernel/uvm/conftest.sh
++++ b/kernel/uvm/conftest.sh
+@@ -196,7 +196,7 @@
+ }
+
+ build_cflags() {
+-    BASE_CFLAGS="-std=gnu17 -O2 -Wno-implicit-function-declaration -Wno-incompatible-pointer-types -D__KERNEL__ \
++    BASE_CFLAGS="-std=gnu17 -fms-extensions -Wunused-but-set-variable=3 -O2 -Wno-implicit-function-declaration -Wno-incompatible-pointer-types -D__KERNEL__ \
+ -DKBUILD_BASENAME=\"#conftest$$\" -DKBUILD_MODNAME=\"#conftest$$\" \
+ -nostdinc -isystem $ISYSTEM"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@
 pkgbase=nvidia-340xx
 pkgname=(nvidia-340xx nvidia-340xx-dkms); [ -n "$NVIDIA_340XX_DKMS_ONLY" ] && pkgname=(nvidia-340xx-dkms)
 pkgver=340.108
-pkgrel=39
+pkgrel=40
 pkgdesc="NVIDIA drivers for linux, 340xx legacy branch"
 arch=('x86_64')
 url="https://www.nvidia.com/"
@@ -37,6 +37,7 @@ source=(
   0017-gcc-14.patch
   0018-gcc-15.patch
   0019-kernel-6.15.patch
+  0020-kernel-6.19.patch
 )
 b2sums=('6538bbec53b10f8d20977f9b462052625742e9709ef06e24cf2e55de5d0c55f1620a4bb21396cfd89ebc54c32f921ea17e3e47eaa95abcbc24ecbd144fb89028'
         '49d99f612e8eee3ab5e34083c25348bfd14ed5fc8a7984dafc0dad7c0ae0df2c0b2a63a1bb993da440eb0a60293d7c753ca3889bd2f51991b8ddc51bce2fe4a8'
@@ -58,7 +59,8 @@ b2sums=('6538bbec53b10f8d20977f9b462052625742e9709ef06e24cf2e55de5d0c55f1620a4bb
         '834cebe75ee128d3a3dc69c1e65c579c23a6d39b1dedd77d1333057696168d264a8131dab88997d73801595fa46bf69a8be02411a383bb2067744cbf754c61a0'
         'fd8393baf8bb3e41a523df0edb82098172d350631e0002eb8dea4a07e40c56687eefa57360e268d908a11a8b7519d7d98b30290cb3e0c00645d85bde899f151b'
         'bf9cea1ec7f1a74d302e7f99544bff88eb846a014a4fb9de96928291ddcaf09c9f40f4ec6f1995e132991b9d7fe0a9ce696ba9e820559cde981fce3bcde06823'
-        'f06a0171e31b0254e0480df25b5f86ca575434822fd7d4a791da9856159c17a82195896ab2a43ab68442d6026d991d8ae2701afb9f8b6e35bf4d336809f60193')
+        'f06a0171e31b0254e0480df25b5f86ca575434822fd7d4a791da9856159c17a82195896ab2a43ab68442d6026d991d8ae2701afb9f8b6e35bf4d336809f60193'
+        'd414291e6e4bfce2310a3b8a97dde726500dc1d28de8d435c82412bdbd884969cc76035d78874dd696bc76be9bfb9c125848c4a79459e1dcc06971cf507c1a8c')
 _pkg="NVIDIA-Linux-x86_64-${pkgver}-no-compat32"
 
 # default is 'linux' substitute custom name here

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@
 pkgbase=nvidia-340xx
 pkgname=(nvidia-340xx nvidia-340xx-dkms); [ -n "$NVIDIA_340XX_DKMS_ONLY" ] && pkgname=(nvidia-340xx-dkms)
 pkgver=340.108
-pkgrel=40
+pkgrel=41
 pkgdesc="NVIDIA drivers for linux, 340xx legacy branch"
 arch=('x86_64')
 url="https://www.nvidia.com/"
@@ -38,6 +38,7 @@ source=(
   0018-gcc-15.patch
   0019-kernel-6.15.patch
   0020-kernel-6.19.patch
+  0021-kernel-7.0.patch
 )
 b2sums=('6538bbec53b10f8d20977f9b462052625742e9709ef06e24cf2e55de5d0c55f1620a4bb21396cfd89ebc54c32f921ea17e3e47eaa95abcbc24ecbd144fb89028'
         '49d99f612e8eee3ab5e34083c25348bfd14ed5fc8a7984dafc0dad7c0ae0df2c0b2a63a1bb993da440eb0a60293d7c753ca3889bd2f51991b8ddc51bce2fe4a8'
@@ -60,7 +61,8 @@ b2sums=('6538bbec53b10f8d20977f9b462052625742e9709ef06e24cf2e55de5d0c55f1620a4bb
         'fd8393baf8bb3e41a523df0edb82098172d350631e0002eb8dea4a07e40c56687eefa57360e268d908a11a8b7519d7d98b30290cb3e0c00645d85bde899f151b'
         'bf9cea1ec7f1a74d302e7f99544bff88eb846a014a4fb9de96928291ddcaf09c9f40f4ec6f1995e132991b9d7fe0a9ce696ba9e820559cde981fce3bcde06823'
         'f06a0171e31b0254e0480df25b5f86ca575434822fd7d4a791da9856159c17a82195896ab2a43ab68442d6026d991d8ae2701afb9f8b6e35bf4d336809f60193'
-        'd414291e6e4bfce2310a3b8a97dde726500dc1d28de8d435c82412bdbd884969cc76035d78874dd696bc76be9bfb9c125848c4a79459e1dcc06971cf507c1a8c')
+        'd414291e6e4bfce2310a3b8a97dde726500dc1d28de8d435c82412bdbd884969cc76035d78874dd696bc76be9bfb9c125848c4a79459e1dcc06971cf507c1a8c'
+        '348f934d252bd91ca6753b821b489f16a3b8ff074583eaf38fda6e6bc64aade07b438aa45f7ed34019335c22449d4829a90b5b3192b9e3688e59345bb883f380')
 _pkg="NVIDIA-Linux-x86_64-${pkgver}-no-compat32"
 
 # default is 'linux' substitute custom name here


### PR DESCRIPTION
- Since Linux kernel `6.19.6-arch1-1`, `nvidia-340xx 340.108-39` doesn't build no more. A function, `in_irq` is no more declared (at least explicitly) :

```
os-interface.c: In function ‘os_is_isr’:
os-interface.c:222:13: error: implicit declaration of function ‘in_irq’ [-Wimplicit-function-declaration]
  222 |     return (in_irq());
```

I found that some others have replaced this function by this one, `in_hardirq` (https://pastebin.com/Rhdy9KHe) and it works.

So, this PR:

- Add `0020-kernel-6.19.patch`, to make this replacement.
- Add `0021-kernel-7.0.patch` (thanks R3n4n).
- Modify `.SRCINFO` and `PKGBUILD` accordingly.
- Bump `pkgrel` to `41` (`nvidia-340xx 340.108-41`)

_N.B._ :Since, I have made more than 12 kernel updates, up to `7.1.2-arch3-1`, without issue.